### PR TITLE
Config diet pass 2: resolve duplication/conflicts

### DIFF
--- a/after/ftplugin/java.lua
+++ b/after/ftplugin/java.lua
@@ -1,1 +1,0 @@
-vim.lsp.enable "jdtls"

--- a/lua/plugins/mini-icons.lua
+++ b/lua/plugins/mini-icons.lua
@@ -1,1 +1,0 @@
-return { "nvim-mini/mini.icons", version = false }

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -1,56 +1,47 @@
 return {
-  {
-    "nvim-telescope/telescope.nvim",
-    dependencies = { "nvim-lua/plenary.nvim" },
-    event = "VeryLazy",
-    config = function()
-      require("telescope").setup {
-        defaults = {
-          vimgrep_arguments = {
-            "rg",
-            "--color=never",
-            "--no-heading",
-            "--with-filename",
-            "--line-number",
-            "--column",
-            "--smart-case",
-            "--hidden",
-            "--glob=!.git/**",
-          },
-          file_ignore_patterns = { "^%.git/" },
-        },
-        pickers = {
-          find_files = {
-            hidden = true,
-          },
-        },
-      }
-      local builtin = require "telescope.builtin"
-      vim.keymap.set("n", "<C-p>", builtin.find_files, { desc = "Telescope: Find files" })
-      vim.keymap.set("n", "sg", builtin.live_grep, { desc = "Telescope: Live grep" })
-      vim.keymap.set("n", "gr", builtin.lsp_references, { desc = "Telescope: LSP references" })
-      vim.keymap.set("n", "<leader>ss", builtin.lsp_document_symbols, { desc = "Telescope LSP Doc symbols" })
-      vim.keymap.set("n", "<leader>sS", builtin.lsp_workspace_symbols, { desc = "Telescope LSP WS symbols" })
-    end,
-  },
-  {
+  "nvim-telescope/telescope.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
     "nvim-telescope/telescope-ui-select.nvim",
-    config = function()
-      require("telescope").setup {
-        extensions = {
-          ["ui-select"] = {
-            require("telescope.themes").get_dropdown {},
-          },
-        },
-      }
-      require("telescope").load_extension "ui-select"
-    end,
-  },
-  {
     "luc-tielen/telescope_hoogle",
-    config = function()
-      local telescope = require "telescope"
-      telescope.load_extension "hoogle"
-    end,
   },
+  event = "VeryLazy",
+  config = function()
+    local telescope = require "telescope"
+    telescope.setup {
+      defaults = {
+        vimgrep_arguments = {
+          "rg",
+          "--color=never",
+          "--no-heading",
+          "--with-filename",
+          "--line-number",
+          "--column",
+          "--smart-case",
+          "--hidden",
+          "--glob=!.git/**",
+        },
+        file_ignore_patterns = { "^%.git/" },
+      },
+      pickers = {
+        find_files = {
+          hidden = true,
+        },
+      },
+      extensions = {
+        ["ui-select"] = {
+          require("telescope.themes").get_dropdown {},
+        },
+      },
+    }
+    telescope.load_extension "ui-select"
+    telescope.load_extension "hoogle"
+
+    local builtin = require "telescope.builtin"
+    vim.keymap.set("n", "<C-p>", builtin.find_files, { desc = "Telescope: Find files" })
+    vim.keymap.set("n", "sg", builtin.live_grep, { desc = "Telescope: Live grep" })
+    vim.keymap.set("n", "gr", builtin.lsp_references, { desc = "Telescope: LSP references" })
+    vim.keymap.set("n", "<leader>ss", builtin.lsp_document_symbols, { desc = "Telescope LSP Doc symbols" })
+    vim.keymap.set("n", "<leader>sS", builtin.lsp_workspace_symbols, { desc = "Telescope LSP WS symbols" })
+  end,
 }


### PR DESCRIPTION
Second diet pass. Axis: behavior-preserving consolidation — resolve
duplicated/conflicting configuration to cut down un-grasped setup, without
removing features. No plugins removed, so `lazy-lock.json` is unchanged. One
commit per item.

## Resolved
- **telescope double `setup`** — telescope-ui-select called
  `require("telescope").setup` a second time with only `extensions`, which
  reset `defaults` (custom `vimgrep_arguments`, git-ignore) and the hidden
  `find_files` picker back to telescope defaults. Folded ui-select and
  telescope_hoogle in as dependencies and configured everything in one
  `setup`, then load both extensions. **Restores the clobbered defaults.**
- **Java jdtls double start** — `after/ftplugin/java.lua`'s
  `vim.lsp.enable "jdtls"` started a second jdtls client (via lspconfig's
  bundled config) alongside nvim-jdtls's `start_or_attach`. Removed the
  native enable; nvim-jdtls is the single path.
- **mini.icons redundant spec** — `lua/plugins/mini-icons.lua` duplicated the
  mini.icons dependency already declared by oil.nvim. Removed; the plugin
  stays via the oil dependency.

## Out of scope (future passes)
- web-devicons ↔ mini.icons consolidation (touches lualine).
- Deprecation modernization (`vim.diagnostic.goto_prev/next`, conform
  `lsp_fallback`).

## Verification
`stylua --check` and `bin/check` pass. Headless check confirms telescope's
custom `vimgrep_arguments` are back and ui-select/hoogle load. CI runs both
checks on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)