### PR TITLE
Typed semantic keymap wrappers + full migration

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,4 +1,5 @@
 {
+    "runtime.version": "LuaJIT",
     "diagnostics.globals": [
         "vim"
     ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,15 @@ LSP uses the Neovim 0.11+ native API instead of lspconfig setup calls:
 ### Custom Modules (`lua/shino/`)
 
 - `commands.lua` — `:InitLua` (open init.lua in editor)
+- `keymap.lua` — typed wrappers over `vim.keymap.set`. Prefer these over
+  `vim.keymap.set` directly:
+  - `map(mode, lhs, rhs, opts?)` — thin escape hatch for multi-mode or
+    unusual mappings; `desc` optional. Defaults `silent = true`.
+  - `nmap`/`imap`/`vmap`/`xmap(lhs, rhs, desc, opts?)` — per-mode helpers
+    with `desc` **required** (every semantic mapping is self-documenting).
+    Buffer-local mappings pass `{ buffer = bufnr }` via `opts`.
+  - `opts` borrows Neovim's `vim.keymap.set.Opts` type, so field completion
+    survives. Do not add dynamic dispatch (`__index`); it defeats LuaLS.
 
 ### Colorscheme
 

--- a/after/ftplugin/haskell.lua
+++ b/after/ftplugin/haskell.lua
@@ -1,18 +1,18 @@
 -- ~/.config/nvim/after/ftplugin/haskell.lua
 local ht = require "haskell-tools"
-local bufnr = vim.api.nvim_get_current_buf()
-local opts = { noremap = true, silent = true, buffer = bufnr }
+local keymap = require "shino.keymap"
+local opts = { buffer = vim.api.nvim_get_current_buf() }
 -- haskell-language-server relies heavily on codeLenses,
 -- so auto-refresh (see advanced configuration) is enabled by default
-vim.keymap.set("n", "<space>cl", vim.lsp.codelens.run, opts)
+keymap.nmap("<space>cl", vim.lsp.codelens.run, "Haskell: Run code lens", opts)
 -- Hoogle search for the type signature of the definition under the cursor
-vim.keymap.set("n", "<space>hs", ht.hoogle.hoogle_signature, opts)
+keymap.nmap("<space>hs", ht.hoogle.hoogle_signature, "Haskell: Hoogle signature", opts)
 -- Evaluate all code snippets
-vim.keymap.set("n", "<space>ea", ht.lsp.buf_eval_all, opts)
+keymap.nmap("<space>ea", ht.lsp.buf_eval_all, "Haskell: Eval all", opts)
 -- Toggle a GHCi repl for the current package
-vim.keymap.set("n", "<leader>rr", ht.repl.toggle, opts)
+keymap.nmap("<leader>rr", ht.repl.toggle, "Haskell: Toggle REPL (package)", opts)
 -- Toggle a GHCi repl for the current buffer
-vim.keymap.set("n", "<leader>rf", function()
+keymap.nmap("<leader>rf", function()
   ht.repl.toggle(vim.api.nvim_buf_get_name(0))
-end, opts)
-vim.keymap.set("n", "<leader>rq", ht.repl.quit, opts)
+end, "Haskell: Toggle REPL (buffer)", opts)
+keymap.nmap("<leader>rq", ht.repl.quit, "Haskell: Quit REPL", opts)

--- a/after/lsp/copilot.lua
+++ b/after/lsp/copilot.lua
@@ -27,22 +27,23 @@ return {
         -- Enable inline completion
         vim.lsp.inline_completion.enable(false, { bufnr = bufnr })
 
-        vim.keymap.set("i", "<c-e>", function()
+        local keymap = require "shino.keymap"
+        keymap.imap("<c-e>", function()
           vim.lsp.inline_completion.get()
           if vim.fn.pumvisible() == 1 then
             return "<c-e>"
           end
-        end, { silent = true, expr = true, buffer = bufnr })
+        end, "Copilot: Trigger inline completion", { expr = true, buffer = bufnr })
         -- Select inline completions
-        vim.keymap.set("i", "<c-f>", function()
+        keymap.imap("<c-f>", function()
           vim.lsp.inline_completion.select()
-        end, { silent = true, buffer = bufnr })
-        vim.keymap.set("i", "<c-b>", function()
+        end, "Copilot: Next inline completion", { buffer = bufnr })
+        keymap.imap("<c-b>", function()
           vim.lsp.inline_completion.select { count = -1 * vim.v.count1 }
-        end, { silent = true, buffer = bufnr })
-        vim.keymap.set("n", "<leader>sc", function()
+        end, "Copilot: Previous inline completion", { buffer = bufnr })
+        keymap.nmap("<leader>sc", function()
           vim.lsp.inline_completion.enable(not vim.lsp.inline_completion.is_enabled())
-        end, { desc = "Toggle Copilot Suggestions", buffer = bufnr })
+        end, "Toggle Copilot Suggestions", { buffer = bufnr })
       end,
     })
   end,

--- a/ftplugin/markdown.lua
+++ b/ftplugin/markdown.lua
@@ -3,7 +3,3 @@ vim.opt_local.wrap = true
 vim.opt_local.linebreak = true
 vim.opt_local.spell = true
 vim.opt_local.conceallevel = 2
-vim.g.mkdp_auto_start = 0 -- Set to 1 to auto start markdown preview window after entering markdown buffer
-vim.g.mkdp_auto_close = 1 -- Set to 1 to auto close current preview window when changing from Markdown buffer
-vim.g.mkdp_refresh_slow = 0
-vim.keymap.set("n", "<leader>mp", ":MarkdownPreview<CR>", { buffer = true, desc = "Markdown Preview" })

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,7 @@
 -- Keymaps
-vim.keymap.set("n", "H", ":bprevious<CR>", { silent = true, noremap = true, desc = "Go to previous tab" })
-vim.keymap.set("n", "L", ":bnext<CR>", { silent = true, noremap = true, desc = "Go to next tab" })
+local keymap = require "shino.keymap"
+keymap.nmap("H", ":bprevious<CR>", "Go to previous tab")
+keymap.nmap("L", ":bnext<CR>", "Go to next tab")
 
 -- set mapleader
 require "vim-options"
@@ -15,37 +16,14 @@ vim.opt.foldlevel = 99
 vim.opt.foldmethod = "expr"
 vim.opt.foldtext = ""
 
--- Arrow * Different interpretation of bytes
-vim.keymap.set("n", "<Right>", "<c-w>>", {
-  noremap = true,
-  desc = "Write right arrow",
-})
-vim.keymap.set("n", "<Left>", "<c-w><", {
-  noremap = true,
-  desc = "Write left arrow",
-})
-vim.keymap.set("n", "<Down>", "<c-w>-", {
-  noremap = true,
-  desc = "Write down arrow",
-})
-vim.keymap.set("n", "<Up>", "<c-w>+", {
-  noremap = true,
-  desc = "Write up arrow",
-})
+-- Arrow keys resize windows in normal mode
+keymap.nmap("<Right>", "<c-w>>", "Write right arrow")
+keymap.nmap("<Left>", "<c-w><", "Write left arrow")
+keymap.nmap("<Down>", "<c-w>-", "Write down arrow")
+keymap.nmap("<Up>", "<c-w>+", "Write up arrow")
 
-vim.keymap.set("i", "<Right>", "→", {
-  noremap = true,
-  desc = "Write right arrow",
-})
-vim.keymap.set("i", "<Left>", "←", {
-  noremap = true,
-  desc = "Write left arrow",
-})
-vim.keymap.set("i", "<Down>", "↓", {
-  noremap = true,
-  desc = "Write down arrow",
-})
-vim.keymap.set("i", "<Up>", "↑", {
-  noremap = true,
-  desc = "Write up arrow",
-})
+-- Arrow keys insert literal Unicode arrows in insert mode
+keymap.imap("<Right>", "→", "Write right arrow")
+keymap.imap("<Left>", "←", "Write left arrow")
+keymap.imap("<Down>", "↓", "Write down arrow")
+keymap.imap("<Up>", "↑", "Write up arrow")

--- a/lua/lsp/keymaps.lua
+++ b/lua/lsp/keymaps.lua
@@ -1,40 +1,40 @@
+local keymap = require "shino.keymap"
+
 local M = {}
 function M.lsp_keymap(bufnr)
-  local function map(mode, lhs, rhs, desc)
-    vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, silent = true, noremap = true, desc = desc })
-  end
+  local opts = { buffer = bufnr }
 
   -- Basics
-  map("n", "K", vim.lsp.buf.hover, "LSP: Hover")
-  map("n", "<leader>gd", function()
+  keymap.nmap("K", vim.lsp.buf.hover, "LSP: Hover", opts)
+  keymap.nmap("<leader>gd", function()
     vim.cmd "belowright split"
     vim.lsp.buf.definition()
-  end, "LSP: Go to definition (vsplit)")
-  map("n", "gd", vim.lsp.buf.definition, "LSP: Go to definition")
-  map("n", "gD", vim.lsp.buf.declaration, "LSP: Go to declaration")
-  map("n", "gi", vim.lsp.buf.implementation, "LSP: Go to implementation")
-  map("n", "gt", vim.lsp.buf.type_definition, "LSP: Go to type")
-  map("n", "<leader>rn", vim.lsp.buf.rename, "LSP: Rename")
-  map({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, "LSP: Code action")
-  map("n", "<leader>sh", vim.lsp.buf.signature_help, "LSP: Signature help")
+  end, "LSP: Go to definition (vsplit)", opts)
+  keymap.nmap("gd", vim.lsp.buf.definition, "LSP: Go to definition", opts)
+  keymap.nmap("gD", vim.lsp.buf.declaration, "LSP: Go to declaration", opts)
+  keymap.nmap("gi", vim.lsp.buf.implementation, "LSP: Go to implementation", opts)
+  keymap.nmap("gt", vim.lsp.buf.type_definition, "LSP: Go to type", opts)
+  keymap.nmap("<leader>rn", vim.lsp.buf.rename, "LSP: Rename", opts)
+  keymap.map({ "n", "v" }, "<leader>ca", vim.lsp.buf.code_action, { buffer = bufnr, desc = "LSP: Code action" })
+  keymap.nmap("<leader>sh", vim.lsp.buf.signature_help, "LSP: Signature help", opts)
 
   -- Diagnostics
-  map("n", "[d", vim.diagnostic.goto_prev, "Diag: Prev")
-  map("n", "]d", vim.diagnostic.goto_next, "Diag: Next")
-  map("n", "<leader>e", vim.diagnostic.open_float, "Diag: Line info")
-  map("n", "<leader>q", vim.diagnostic.setloclist, "Diag: To loclist")
+  keymap.nmap("[d", vim.diagnostic.goto_prev, "Diag: Prev", opts)
+  keymap.nmap("]d", vim.diagnostic.goto_next, "Diag: Next", opts)
+  keymap.nmap("<leader>e", vim.diagnostic.open_float, "Diag: Line info", opts)
+  keymap.nmap("<leader>q", vim.diagnostic.setloclist, "Diag: To loclist", opts)
 
   -- Formatting (use Conform.nvim with LSP fallback)
-  map({ "n", "v" }, "<leader>f", function()
+  keymap.map({ "n", "v" }, "<leader>f", function()
     require("conform").format { async = true, lsp_fallback = true }
-  end, "Format with Conform")
+  end, { buffer = bufnr, desc = "Format with Conform" })
 
   -- Inlay hints toggle (NVIM ≥0.10)
   if vim.lsp.inlay_hint then
-    map("n", "<leader>lh", function()
+    keymap.nmap("<leader>lh", function()
       local enabled = vim.lsp.inlay_hint.is_enabled { bufnr = bufnr }
       vim.lsp.inlay_hint.enable(not enabled, { bufnr = bufnr })
-    end, "LSP: Toggle inlay hints")
+    end, "LSP: Toggle inlay hints", opts)
   end
 end
 

--- a/lua/plugins/catppuccin.lua
+++ b/lua/plugins/catppuccin.lua
@@ -28,11 +28,11 @@ return {
     vim.cmd "highlight TelescopeSelection cterm=bold gui=bold guifg=#a6e3a1 guibg=#181825"
 
     -- Transparency toggle keymap
-    vim.keymap.set("n", "<leader>tp", function()
+    require("shino.keymap").nmap("<leader>tp", function()
       local cat = require "catppuccin"
       cat.options.transparent_background = not cat.options.transparent_background
       cat.compile()
       vim.cmd.colorscheme "catppuccin-mocha"
-    end, { desc = "Toggle transparency" })
+    end, "Toggle transparency")
   end,
 }

--- a/lua/plugins/luasnip.lua
+++ b/lua/plugins/luasnip.lua
@@ -6,21 +6,22 @@ return {
 
   config = function()
     local ls = require "luasnip"
-    vim.keymap.set({ "i" }, "<C-K><C-K>", function()
+    local keymap = require "shino.keymap"
+    keymap.map({ "i" }, "<C-K><C-K>", function()
       ls.expand()
-    end, { silent = true })
-    vim.keymap.set({ "i", "s" }, "<C-K><C-L>", function()
+    end, { desc = "LuaSnip: Expand" })
+    keymap.map({ "i", "s" }, "<C-K><C-L>", function()
       ls.jump(1)
-    end, { silent = true })
-    vim.keymap.set({ "i", "s" }, "<C-K><C-J>", function()
+    end, { desc = "LuaSnip: Jump forward" })
+    keymap.map({ "i", "s" }, "<C-K><C-J>", function()
       ls.jump(-1)
-    end, { silent = true })
+    end, { desc = "LuaSnip: Jump backward" })
 
-    vim.keymap.set({ "i", "s" }, "<C-K><C-E>", function()
+    keymap.map({ "i", "s" }, "<C-K><C-E>", function()
       if ls.choice_active() then
         ls.change_choice(1)
       end
-    end, { silent = true })
+    end, { desc = "LuaSnip: Next choice" })
 
     -- Load snippets from separate files
     local snippet_files = {

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -38,10 +38,11 @@ return {
     telescope.load_extension "hoogle"
 
     local builtin = require "telescope.builtin"
-    vim.keymap.set("n", "<C-p>", builtin.find_files, { desc = "Telescope: Find files" })
-    vim.keymap.set("n", "sg", builtin.live_grep, { desc = "Telescope: Live grep" })
-    vim.keymap.set("n", "gr", builtin.lsp_references, { desc = "Telescope: LSP references" })
-    vim.keymap.set("n", "<leader>ss", builtin.lsp_document_symbols, { desc = "Telescope LSP Doc symbols" })
-    vim.keymap.set("n", "<leader>sS", builtin.lsp_workspace_symbols, { desc = "Telescope LSP WS symbols" })
+    local keymap = require "shino.keymap"
+    keymap.nmap("<C-p>", builtin.find_files, "Telescope: Find files")
+    keymap.nmap("sg", builtin.live_grep, "Telescope: Live grep")
+    keymap.nmap("gr", builtin.lsp_references, "Telescope: LSP references")
+    keymap.nmap("<leader>ss", builtin.lsp_document_symbols, "Telescope LSP Doc symbols")
+    keymap.nmap("<leader>sS", builtin.lsp_workspace_symbols, "Telescope LSP WS symbols")
   end,
 }

--- a/lua/shino/keymap.lua
+++ b/lua/shino/keymap.lua
@@ -1,0 +1,58 @@
+-- Typed, semantic wrappers around vim.keymap.set.
+--
+-- `map` is the thin escape hatch for multi-mode or unusual mappings; the
+-- per-mode helpers (`nmap`, `imap`, `vmap`, `xmap`) make `desc` a required
+-- positional argument so every semantic mapping is self-documenting. The
+-- `opts` type is borrowed from Neovim's own `vim.keymap.set.Opts`, so
+-- completion and diagnostics on the fields (buffer, silent, ...) survive the
+-- abstraction. Buffer-local mappings are expressed via `opts.buffer`.
+
+local M = {}
+
+---Set a key mapping. Defaults `silent = true` unless overridden.
+---@param mode string|string[]
+---@param lhs string
+---@param rhs string|function
+---@param opts? vim.keymap.set.Opts
+function M.map(mode, lhs, rhs, opts)
+  opts = vim.tbl_extend("keep", opts or {}, { silent = true })
+  vim.keymap.set(mode, lhs, rhs, opts)
+end
+
+---Normal-mode mapping. `desc` is required.
+---@param lhs string
+---@param rhs string|function
+---@param desc string
+---@param opts? vim.keymap.set.Opts
+function M.nmap(lhs, rhs, desc, opts)
+  M.map("n", lhs, rhs, vim.tbl_extend("force", opts or {}, { desc = desc }))
+end
+
+---Insert-mode mapping. `desc` is required.
+---@param lhs string
+---@param rhs string|function
+---@param desc string
+---@param opts? vim.keymap.set.Opts
+function M.imap(lhs, rhs, desc, opts)
+  M.map("i", lhs, rhs, vim.tbl_extend("force", opts or {}, { desc = desc }))
+end
+
+---Visual-mode mapping. `desc` is required.
+---@param lhs string
+---@param rhs string|function
+---@param desc string
+---@param opts? vim.keymap.set.Opts
+function M.vmap(lhs, rhs, desc, opts)
+  M.map("v", lhs, rhs, vim.tbl_extend("force", opts or {}, { desc = desc }))
+end
+
+---Visual-block (x) mode mapping. `desc` is required.
+---@param lhs string
+---@param rhs string|function
+---@param desc string
+---@param opts? vim.keymap.set.Opts
+function M.xmap(lhs, rhs, desc, opts)
+  M.map("x", lhs, rhs, vim.tbl_extend("force", opts or {}, { desc = desc }))
+end
+
+return M


### PR DESCRIPTION
Introduce a typed, semantic keymap utility (`lua/shino/keymap.lua`) and
migrate every `vim.keymap.set` call site to it. Goal: cut the repeated
`{ noremap, silent, desc, buffer }` boilerplate while keeping lazydev/LuaLS
completion intact.

## Design
- `map(mode, lhs, rhs, opts?)` — thin escape hatch (multi-mode / unusual
  maps), `desc` optional, defaults `silent = true`.
- `nmap`/`imap`/`vmap`/`xmap(lhs, rhs, desc, opts?)` — per-mode helpers with
  **`desc` required** (self-documenting). Buffer-local maps via `opts.buffer`.
- `opts` borrows Neovim's `vim.keymap.set.Opts` type so field completion
  survives. No dynamic dispatch (`__index`), which would defeat LuaLS.
- `.luarc.json`: added `runtime.version = "LuaJIT"`.

## Migrated (all call sites; only shino/keymap.lua now calls vim.keymap.set)
- `init.lua` — buffer nav + arrow-key maps.
- `lua/lsp/keymaps.lua` — dropped the local `map` closure; shared
  `{ buffer = bufnr }` opts.
- `after/ftplugin/haskell.lua` — comments promoted to required descs.
- plugin specs: telescope, luasnip ({i,s} via thin `map`), catppuccin, copilot
  (descs added to the previously undocumented inline maps).

## Also
- `fix(markdown)`: removed orphaned markdown-preview leftovers (`<leader>mp`
  and `mkdp_*`) left dead by the first diet pass.
- `CLAUDE.md`: documented the keymap convention.

## Out of scope (future passes)
- CI `lua-language-server --check` (needs lazydev-equivalent library parity).
- Deprecation modernization (`vim.diagnostic.goto_prev/next`, conform
  `lsp_fallback`).

## Verification
`stylua --check` and `bin/check` pass. Headless check confirms migrated
global maps register with correct rhs/desc, semantic helpers set desc +
default silent, and `opts` overrides (e.g. `silent = false`) still apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)