### PR TITLE
Modernize deprecated APIs (diagnostic.jump, conform lsp_format)

### DIFF
--- a/lua/lsp/keymaps.lua
+++ b/lua/lsp/keymaps.lua
@@ -19,8 +19,12 @@ function M.lsp_keymap(bufnr)
   keymap.nmap("<leader>sh", vim.lsp.buf.signature_help, "LSP: Signature help", opts)
 
   -- Diagnostics
-  keymap.nmap("[d", vim.diagnostic.goto_prev, "Diag: Prev", opts)
-  keymap.nmap("]d", vim.diagnostic.goto_next, "Diag: Next", opts)
+  keymap.nmap("[d", function()
+    vim.diagnostic.jump { count = -1, float = true }
+  end, "Diag: Prev", opts)
+  keymap.nmap("]d", function()
+    vim.diagnostic.jump { count = 1, float = true }
+  end, "Diag: Next", opts)
   keymap.nmap("<leader>e", vim.diagnostic.open_float, "Diag: Line info", opts)
   keymap.nmap("<leader>q", vim.diagnostic.setloclist, "Diag: To loclist", opts)
 

--- a/lua/lsp/keymaps.lua
+++ b/lua/lsp/keymaps.lua
@@ -30,7 +30,7 @@ function M.lsp_keymap(bufnr)
 
   -- Formatting (use Conform.nvim with LSP fallback)
   keymap.map({ "n", "v" }, "<leader>f", function()
-    require("conform").format { async = true, lsp_fallback = true }
+    require("conform").format { async = true, lsp_format = "fallback" }
   end, { buffer = bufnr, desc = "Format with Conform" })
 
   -- Inlay hints toggle (NVIM ≥0.10)

--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -29,7 +29,7 @@ return {
         if vim.bo[bufnr].filetype == "haskell" then
           return
         end
-        return { timeout_ms = 10000, lsp_fallback = false }
+        return { timeout_ms = 10000, lsp_format = "never" }
       end,
     }
 


### PR DESCRIPTION
Replace the two deprecated API families found by a full sweep. Scope is
exactly these; `(vim.uv or vim.loop)` in config/lazy.lua is the recommended
idiom (not a deprecation) and inlay_hint already uses the 0.11 signature, so
both are left untouched.

## Changes
- **diagnostic** — `vim.diagnostic.goto_prev/next` (deprecated in 0.11) →
  `vim.diagnostic.jump({ count = -1|1, float = true })`. `float = true`
  preserves the old behavior of opening the diagnostic float after jumping.
- **conform** — the boolean `lsp_fallback` → the string `lsp_format`:
  `false` → `"never"` (format_on_save), `true` → `"fallback"` (the
  `<leader>f` map).

## Verification
- grep assertion: no `goto_prev`/`goto_next`/`lsp_fallback` remain.
- headless smoke: `vim.diagnostic.jump` is a function, conform loads.
- `stylua --check` and `bin/check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)