### PR TITLE
fix(conform): use nixfmt for Nix, matching the environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Run manually:
 stylua lua/ after/ ftplugin/ init.lua
 ```
 
-Format-on-save via Conform is enabled for Lua (stylua), Nix (alejandra), and disabled for Haskell (fourmolu must be run manually with `<leader>f`).
+Format-on-save via Conform is enabled for Lua (stylua), Nix (nixfmt), and disabled for Haskell (fourmolu must be run manually with `<leader>f`).
 
 ## CI
 

--- a/lua/plugins/conform.lua
+++ b/lua/plugins/conform.lua
@@ -20,7 +20,7 @@ return {
       formatters_by_ft = {
         lua = { "stylua" },
         haskell = { "fourmolu" },
-        nix = { "alejandra" },
+        nix = { "nixfmt" },
       },
       format_on_save = function(bufnr)
         if vim.g.disable_autoformat or vim.b[bufnr].disable_autoformat then


### PR DESCRIPTION
`conform.lua` formatted Nix with **alejandra**, but the environment
(hypatia-tile/dotfiles-mac, ADR 0012) dropped alejandra and standardized on
**nixfmt-rfc-style**. Confirmed on this machine: `alejandra` is not on PATH,
`nixfmt` 1.3.1 is. So Nix format-on-save / `<leader>f` currently fails with a
missing formatter (or, if any alejandra lingered, would churn against the
dotfiles' nixfmt output).

## Change
- `lua/plugins/conform.lua`: `nix = { "alejandra" }` → `nix = { "nixfmt" }`.
- `CLAUDE.md`: doc updated (Nix formatter is nixfmt).

conform's `nixfmt` formatter invokes the `nixfmt` binary on PATH, which in
this environment is nixfmt-rfc-style — so nvim and the dotfiles now agree.

## Verification
Headless format of a scratch `.nix` buffer reformats correctly to
nixfmt-rfc-style output. `stylua --check` and `bin/check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)