### PR TITLE
ci: add lua-language-server type-check (non-blocking)

### DIFF
--- a/.github/luarc.ci.json
+++ b/.github/luarc.ci.json
@@ -1,0 +1,10 @@
+{
+    "runtime.version": "LuaJIT",
+    "diagnostics.globals": [
+        "vim"
+    ],
+    "workspace.checkThirdParty": false,
+    "diagnostics.disable": [
+        "undefined-field"
+    ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,63 @@ jobs:
 
       - name: Headless load check
         run: bin/check
+
+  typecheck:
+    # Not yet in branch protection: informative while it is stabilized, then
+    # promoted to a required check once clean.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Install Deno
+        # denops.vim / skkeleton may touch Deno during the restore startup.
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Cache plugins
+        # Shares the key with the `check` job so plugins are installed once.
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/nvim-dev
+          key: nvim-dev-plugins-${{ hashFiles('lazy-lock.json') }}
+          restore-keys: nvim-dev-plugins-
+
+      - name: Restore plugins (no startup check)
+        # Populate the nvim-dev data dir so plugin type definitions are on disk;
+        # bin/check's full startup check is redundant here.
+        run: |
+          ln -sfn "$GITHUB_WORKSPACE" "$HOME/.config/nvim-dev" 2>/dev/null || {
+            mkdir -p "$HOME/.config" && ln -sfn "$GITHUB_WORKSPACE" "$HOME/.config/nvim-dev"
+          }
+          NVIM_APPNAME=nvim-dev nvim --headless "+Lazy! restore" +qa
+
+      - name: Install lua-language-server
+        run: |
+          ver=3.18.2
+          url="https://github.com/LuaLS/lua-language-server/releases/download/${ver}/lua-language-server-${ver}-linux-x64.tar.gz"
+          mkdir -p "$HOME/luals"
+          curl -fsSL "$url" | tar -xz -C "$HOME/luals"
+          echo "$HOME/luals/bin" >> "$GITHUB_PATH"
+
+      - name: Build CI luarc (inject library paths)
+        # LuaLS luarc cannot expand env vars, so resolve $VIMRUNTIME and the
+        # installed plugin lua dirs here and write the effective .luarc.json.
+        # This mirrors what lazydev supplies in-editor.
+        run: |
+          vimruntime="$(nvim --headless --clean -c 'lua io.write(vim.env.VIMRUNTIME)' -c 'qa' 2>/dev/null)"
+          libs="$(printf '%s\n' "$vimruntime" "$HOME"/.local/share/nvim-dev/lazy/*/lua | jq -R . | jq -s .)"
+          jq --argjson libs "$libs" '. + {"workspace.library": $libs}' .github/luarc.ci.json > .luarc.json
+          echo "Effective .luarc.json:"; cat .luarc.json
+
+      - name: lua-language-server --check
+        # --check prints diagnostics and exits non-zero when problems are
+        # found, so the exit code is the signal (this version writes no
+        # check.json).
+        run: lua-language-server --check . --checklevel Warning --logpath /tmp/luals-log


### PR DESCRIPTION
Adds a `typecheck` CI job running `lua-language-server --check` over the Lua
sources, the deferred item from the keymap-util pass.

## lazydev parity in CI
lazydev only supplies LuaLS type libraries **inside Neovim**. The job
reproduces that for standalone LuaLS:
1. Install Neovim (stable) + Deno, restore plugins into the `nvim-dev` data
   dir (shared cache key with `check`).
2. Inject `workspace.library` = `$VIMRUNTIME` + the installed plugin `lua`
   dirs into a committed base (`.github/luarc.ci.json`), written as the
   effective `.luarc.json` (LuaLS can't expand env vars, so paths are
   resolved at run time). The repo's own `.luarc.json` (editor/lazydev) is
   left untouched.
3. `lua-language-server --check .` — exits non-zero on problems (this version
   writes no check.json, so the exit code is the signal). Pinned to 3.18.2.

## Settings
- checklevel: **Warning**.
- `undefined-field` **disabled**: every current finding (23, all in
  LuaSnip-related files) was a false positive from LuaSnip's incomplete field
  annotations (`ls.text_node`, …). The useful diagnostics — type mismatches,
  undefined-global, missing-parameter, etc. — stay on. Open to re-enabling
  later with per-plugin typing.

## Rollout
The job is **not in branch protection yet** (informative, can go red without
blocking merges). Promote it to a required check once trusted.

## Verification
Reproduced locally with LuaLS 3.18.2-dev + the same library injection:
0 problems, exit 0. Before disabling `undefined-field`: 23 problems in 6
files, all LuaSnip interop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)